### PR TITLE
fix loading equitdist distortion model from yaml.

### DIFF
--- a/src/CameraCalibration.cpp
+++ b/src/CameraCalibration.cpp
@@ -49,7 +49,7 @@ void CameraCalibration::loadFromFile(const std::string& calibration_yaml_file) {
   if (distortionModelName == "plumb_bob") {
     loadRadTanDistortion(calibration_yaml_file);
   } else if (distortionModelName == "equidistant") {
-    loadRadTanDistortion(calibration_yaml_file);
+    loadEquidistDistortion(calibration_yaml_file);
   } else {
     std::cout << "ERROR: no camera Model detected!" << std::endl;
     return;


### PR DESCRIPTION
Fixed 'terminate called after throwing an instance of 'YAML::TypedBadConversion<double>' exception when loading camera with equidistant distortion model.
